### PR TITLE
Allow redix config using `url`

### DIFF
--- a/lib/nebulex_redis_adapter.ex
+++ b/lib/nebulex_redis_adapter.ex
@@ -179,7 +179,7 @@ defmodule NebulexRedisAdapter do
 
         url ->
           opts = opts |> Keyword.delete(:url)
-          Supervisor.child_spec({Redix, [url, opts]}, id: {Redix, i})
+          Supervisor.child_spec({Redix, {url, opts}}, id: {Redix, i})
       end
     end
   end

--- a/lib/nebulex_redis_adapter.ex
+++ b/lib/nebulex_redis_adapter.ex
@@ -173,14 +173,14 @@ defmodule NebulexRedisAdapter do
         |> Keyword.delete(:pool_size)
         |> Keyword.put(:name, :"#{cache}_redix_#{i}")
 
-      opts =
-        if url = opts[:url] do
-          url
-        else
-          opts
-        end
+      case opts[:url] do
+        nil ->
+          Supervisor.child_spec({Redix, opts}, id: {Redix, i})
 
-      Supervisor.child_spec({Redix, opts}, id: {Redix, i})
+        url ->
+          opts = opts |> Keyword.delete(:url)
+          Supervisor.child_spec({Redix, [url, opts]}, id: {Redix, i})
+      end
     end
   end
 

--- a/lib/nebulex_redis_adapter.ex
+++ b/lib/nebulex_redis_adapter.ex
@@ -173,6 +173,13 @@ defmodule NebulexRedisAdapter do
         |> Keyword.delete(:pool_size)
         |> Keyword.put(:name, :"#{cache}_redix_#{i}")
 
+      opts =
+        if url = opts[:url] do
+          url
+        else
+          opts
+        end
+
       Supervisor.child_spec({Redix, opts}, id: {Redix, i})
     end
   end


### PR DESCRIPTION
Redix allows you to specify a Redis URI instead of host/port information. This allows you to have a config like:
```elixir
config :nebulex, MyApp.RedisCache,
  pools: [
    primary: [
      url: System.get_env("REDIS_URL"),
      pool_size: 10
    ]
  ]
```