### PR TITLE
Replaced the redis FLUSHALL command by FLUSHDB

### DIFF
--- a/lib/nebulex_redis_adapter.ex
+++ b/lib/nebulex_redis_adapter.ex
@@ -416,7 +416,7 @@ defmodule NebulexRedisAdapter do
 
   @impl true
   def flush(cache) do
-    _ = exec!(cache.__mode__, [cache, ["FLUSHALL"]], [])
+    _ = exec!(cache.__mode__, [cache, ["FLUSHDB"]], [])
     :ok
   end
 


### PR DESCRIPTION
When working with a shared redis server, the FLUSHALL command will clear all caches entries from the other redis users.
All tests are running properly.