### PR TITLE
Compression of data in Redis

### DIFF
--- a/lib/nebulex_redis_adapter.ex
+++ b/lib/nebulex_redis_adapter.ex
@@ -57,6 +57,9 @@ defmodule NebulexRedisAdapter do
       since the object contains not only the value but also the key, the TTL,
       and the version. This is the default.
 
+    * `:compressed` - just like `:object`, but passes [:compressed] option
+      to :erlang.term_to_binary/2
+
     * `:string` - If this option is set and the object value can be converted
       to a valid string (e.g.: strings, integers, atoms), then that string is
       stored directly in Redis without any encoding.

--- a/lib/nebulex_redis_adapter/encoder.ex
+++ b/lib/nebulex_redis_adapter/encoder.ex
@@ -12,6 +12,10 @@ defmodule NebulexRedisAdapter.Encoder do
     to_string(data)
   end
 
+  def encode(data, :compressed) do
+    :erlang.term_to_binary(data, [:compressed])
+  end
+
   def encode(data, _) do
     to_string(data)
   rescue

--- a/test/shared/cache_test.exs
+++ b/test/shared/cache_test.exs
@@ -87,6 +87,11 @@ defmodule NebulexRedisAdapter.CacheTest do
         assert %{"foo" => "bar", 1 => "1", :a => "a"} == @cache.get_many(["foo", 1, :a])
       end
 
+      test "compressed data type" do
+        assert "bar" == @cache.set("foo", %{answer: 42}, dt: :compressed)
+        assert %{answer: 42} == @cache.get("foo")
+      end
+
       ## Private Functions
 
       defp to_int(keys), do: :lists.usort(for(k <- keys, do: String.to_integer(k)))

--- a/test/shared/cache_test.exs
+++ b/test/shared/cache_test.exs
@@ -88,8 +88,8 @@ defmodule NebulexRedisAdapter.CacheTest do
       end
 
       test "compressed data type" do
-        assert "bar" == @cache.set("foo", %{answer: 42}, dt: :compressed)
-        assert %{answer: 42} == @cache.get("foo")
+        assert %{bar: 42} == @cache.set("foo", %{bar: 42}, dt: :compressed)
+        assert %{bar: 42} == @cache.get("foo")
       end
 
       ## Private Functions


### PR DESCRIPTION
By default, the adapter encodes all the data via `:erlang.term_to_binary/1` function which optionally accepts `[:compressed]` as a 2-nd argument. This option can reduce Redis memory consumption.

The compression rate depends on the nature of the data cached, so I decided to make it configurable on per-key basis (rather than on per-nebulex-cache-instance basis) by introducing `:compressed` data type:

```
@cache.set("foo", %{bar: 42}, dt: :compressed)
```