### PR TITLE
Allow telemetry 1.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -50,7 +50,7 @@ defmodule NebulexRedisAdapter.MixProject do
       {:redix, "~> 1.1"},
       {:crc, "~> 0.10", optional: true},
       {:jchash, "~> 0.1.2", optional: true},
-      {:telemetry, "~> 0.4", optional: true},
+      {:telemetry, "~> 0.4 or ~> 1.0", optional: true},
 
       # Test & Code Analysis
       {:excoveralls, "~> 0.14", only: :test},


### PR DESCRIPTION
Updates the telemetry dependency to allow ~> 0.4 or ~> 1.0.