### PR TITLE
Support nebulex 2.4

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,6 +4,7 @@ defmodule NebulexRedisAdapter.MixProject do
   @source_url "https://github.com/cabol/nebulex_redis_adapter"
   @version "2.2.0"
   @nbx_vsn "2.3.2"
+  @nbx_tag "2.0"
 
   def project do
     [
@@ -70,9 +71,9 @@ defmodule NebulexRedisAdapter.MixProject do
 
   defp nebulex_dep do
     if path = System.get_env("NEBULEX_PATH") do
-      {:nebulex, "~> #{@nbx_vsn}", path: path}
+      {:nebulex, "~> #{@nbx_tag}", path: path}
     else
-      {:nebulex, "~> #{@nbx_vsn}"}
+      {:nebulex, "~> #{@nbx_tag}"}
     end
   end
 


### PR DESCRIPTION
This PR updates the required nebulex version to `~> 2.0` (>= 2.0.0 and < 3.0.0) for supporting nebulex 2.4.

If you don't want to support < 2.3, I will change the required nebulex version to `~> 2.3`.