### PR TITLE
Log Cluster Connections Error

### DIFF
--- a/lib/nebulex_redis_adapter/redis_cluster/config_manager.ex
+++ b/lib/nebulex_redis_adapter/redis_cluster/config_manager.ex
@@ -5,6 +5,7 @@ defmodule NebulexRedisAdapter.RedisCluster.ConfigManager do
 
   import Nebulex.Helpers, only: [normalize_module_name: 1]
   import NebulexRedisAdapter.Helpers
+  require Logger
 
   alias Nebulex.Telemetry
   alias NebulexRedisAdapter.{Connection, RedisCluster}
@@ -106,8 +107,8 @@ defmodule NebulexRedisAdapter.RedisCluster.ConfigManager do
 
         {:noreply, %{state | running_shards: running_shards, setup_retries: 1}}
 
-      {:error, _reason} ->
-        # Set cluster status to error
+      {:error, reason} ->
+        Logger.error(inspect(reason))
         :ok = RedisCluster.put_status(name, :error)
 
         {:noreply, %{state | running_shards: [], setup_retries: n + 1}, random_timeout(n)}

--- a/lib/nebulex_redis_adapter/redis_cluster/config_manager.ex
+++ b/lib/nebulex_redis_adapter/redis_cluster/config_manager.ex
@@ -108,7 +108,9 @@ defmodule NebulexRedisAdapter.RedisCluster.ConfigManager do
         {:noreply, %{state | running_shards: running_shards, setup_retries: 1}}
 
       {:error, reason} ->
+        # Log the error
         Logger.error(inspect(reason))
+        # Set cluster status to error
         :ok = RedisCluster.put_status(name, :error)
 
         {:noreply, %{state | running_shards: [], setup_retries: n + 1}, random_timeout(n)}


### PR DESCRIPTION
Related: #36 

I had misconfigured my adapter and it was hard to figure out why. The cluster status was just in an `:error` state. I thought it would be nice to surface the actual reason in the logs.