### PR TITLE
Support tuples as keys for get_all/put_all callbacks in Redis/Client cluster

### DIFF
--- a/lib/nebulex_redis_adapter/client_cluster.ex
+++ b/lib/nebulex_redis_adapter/client_cluster.ex
@@ -102,19 +102,13 @@ defmodule NebulexRedisAdapter.ClientCluster do
     Pool.get_conn(registry, {name, node_name}, pool_size)
   end
 
-  @spec group_keys_by_hash_slot(Enum.t(), nodes_config, module) :: map
-  def group_keys_by_hash_slot(enum, nodes, module) do
-    Enum.reduce(enum, %{}, fn
-      {key, _} = entry, acc ->
-        hash_slot = hash_slot(module, key, nodes)
+  @spec group_keys_by_hash_slot(Enum.t(), nodes_config, module, atom()) :: map
+  def group_keys_by_hash_slot(enum, nodes, module, :keys) do
+    Enum.group_by(enum, &hash_slot(module, &1, nodes))
+  end
 
-        Map.put(acc, hash_slot, [entry | Map.get(acc, hash_slot, [])])
-
-      key, acc ->
-        hash_slot = hash_slot(module, key, nodes)
-
-        Map.put(acc, hash_slot, [key | Map.get(acc, hash_slot, [])])
-    end)
+  def group_keys_by_hash_slot(enum, nodes, module, :tuples) do
+    Enum.group_by(enum, fn {key, _} -> hash_slot(module, key, nodes) end)
   end
 
   ## Private Functions

--- a/lib/nebulex_redis_adapter/redis_cluster.ex
+++ b/lib/nebulex_redis_adapter/redis_cluster.ex
@@ -111,19 +111,13 @@ defmodule NebulexRedisAdapter.RedisCluster do
     end)
   end
 
-  @spec group_keys_by_hash_slot(Enum.t(), module) :: map
-  def group_keys_by_hash_slot(enum, keyslot) do
-    Enum.reduce(enum, %{}, fn
-      {key, _} = entry, acc ->
-        slot = hash_slot(key, keyslot)
+  @spec group_keys_by_hash_slot(Enum.t(), module, atom()) :: map
+  def group_keys_by_hash_slot(enum, keyslot, :keys) do
+    Enum.group_by(enum, &hash_slot(&1, keyslot))
+  end
 
-        Map.put(acc, slot, [entry | Map.get(acc, slot, [])])
-
-      key, acc ->
-        slot = hash_slot(key, keyslot)
-
-        Map.put(acc, slot, [key | Map.get(acc, slot, [])])
-    end)
+  def group_keys_by_hash_slot(enum, keyslot, :tuples) do
+    Enum.group_by(enum, fn {key, _} -> hash_slot(key, keyslot) end)
   end
 
   @spec hash_slot(any, module) :: {:"$hash_slot", pos_integer}

--- a/test/nebulex_redis_adapter/redis_cluster_test.exs
+++ b/test/nebulex_redis_adapter/redis_cluster_test.exs
@@ -160,6 +160,31 @@ defmodule NebulexRedisAdapter.RedisClusterTest do
 
       assert Cache.get_all(["{foo}.1", "{foo}.2"]) == %{"{foo}.1" => "bar1", "{foo}.2" => "bar2"}
     end
+
+    test "put and get operations with tupled keys" do
+      assert Cache.put_all(%{
+               {RedisCache.Testing, "key1"} => "bar1",
+               {RedisCache.Testing, "key2"} => "bar2"
+             }) == :ok
+
+      assert Cache.get_all([{RedisCache.Testing, "key1"}, {RedisCache.Testing, "key2"}]) == %{
+               {RedisCache.Testing, "key1"} => "bar1",
+               {RedisCache.Testing, "key2"} => "bar2"
+             }
+
+      assert Cache.put_all(%{
+               {RedisCache.Testing, {Nested, "key1"}} => "bar1",
+               {RedisCache.Testing, {Nested, "key2"}} => "bar2"
+             }) == :ok
+
+      assert Cache.get_all([
+               {RedisCache.Testing, {Nested, "key1"}},
+               {RedisCache.Testing, {Nested, "key2"}}
+             ]) == %{
+               {RedisCache.Testing, {Nested, "key1"}} => "bar1",
+               {RedisCache.Testing, {Nested, "key2"}} => "bar2"
+             }
+    end
   end
 
   describe "MOVED" do


### PR DESCRIPTION
In the Nebulex README [Quickstart example](https://github.com/cabol/nebulex?tab=readme-ov-file#quickstart-example), there are cases where the keys are Elixir tuples.

```elixir
  @decorate cache_evict(
              cache: Cache,
              keys: [{User, user.id}, {User, user.username}]
            )
  def delete_user(%User{} = user) do
    Repo.delete(user)
  end
```

Tuples as keys work perfectly fine in  `nebulex_redis_adapter` with a `standalone`. They also work fine with `nebulex_redis_adapter` in `redis_cluster`/`client_cluster` mode.

However, `get_all` and `put_all` callbacks don't work properly with tuples as keys.
When running those callbacks with tuples as keys, `CROSSLOT` errors often occur. 

Example:
```
 1) test MOVED put and get operations with tuple keys (NebulexRedisAdapter.RedisClusterTest)
     test/nebulex_redis_adapter/redis_cluster_test.exs:188
     ** (Redix.Error) CROSSSLOT Keys in request don't hash to the same slot
     code: assert Cache.get_all([{RedisCache.Testing, "key1"}, {RedisCache.Testing, "key2"}]) == %{
     stacktrace:
       (nebulex_redis_adapter 2.3.1) lib/nebulex_redis_adapter/command.ex:167: NebulexRedisAdapter.Command.handle_command_response/2
       (nebulex_redis_adapter 2.3.1) lib/nebulex_redis_adapter.ex:559: NebulexRedisAdapter.mget/4
       (nebulex_redis_adapter 2.3.1) lib/nebulex_redis_adapter.ex:542: anonymous fn/4 in NebulexRedisAdapter.do_get_all/3
       (stdlib 3.17.2.1) maps.erl:410: :maps.fold_1/3
       (nebulex_redis_adapter 2.3.1) lib/nebulex_redis_adapter.ex:530: anonymous fn/4 in NebulexRedisAdapter.get_all/3
       (telemetry 1.2.1) /Users/Daniel.Kulesza/Projects/nebulex_redis_adapter/deps/telemetry/src/telemetry.erl:321: :telemetry.span/3
       test/nebulex_redis_adapter/redis_cluster_test.exs:194: (test)

```

This appears because the `group_keys_by_hash_slot` function takes an `Enum.t()` of:
* any values as keys with grouping keys for a `get_all`
OR
* tuples when grouping keys for a `put_all`

The change in this Pull Request aims to resolve this issue by specifying an atom (`:keys`/`:tuples`) as an argument to differentiate between the two cases. 
