### PR TITLE
handle multiple slot ranges

### DIFF
--- a/lib/nebulex_redis_adapter/redis_cluster/config_manager.ex
+++ b/lib/nebulex_redis_adapter/redis_cluster/config_manager.ex
@@ -263,7 +263,7 @@ defmodule NebulexRedisAdapter.RedisCluster.ConfigManager do
 
     Enum.reduce(config, [], fn
       # Redis version >= 7 (["CLUSTER", "SHARDS"])
-      ["slots", [start, stop], "nodes", nodes], acc ->
+      ["slots", slot_ranges, "nodes", nodes], acc ->
         case parse_node_attrs(nodes) do
           [] ->
             # coveralls-ignore-start
@@ -275,7 +275,9 @@ defmodule NebulexRedisAdapter.RedisCluster.ConfigManager do
             host = attrs["endpoint"]
             port = attrs["tls-port"] || attrs["port"]
 
-            [{start, stop, host, port} | acc]
+            slot_ranges
+            |> Enum.chunk_every(2)
+            |> Enum.reduce(acc, fn [start, stop], acc -> [{start, stop, host, port} | acc] end)
         end
 
       # Redis version < 7 (["CLUSTER", "SLOTS"])


### PR DESCRIPTION
For a Redis cluster, it may have multiple slot ranges in one shard. For example:
`
[
    "slots",
    [5462, 5972, 7338, 8192],
    "nodes",
    [...]
  ]
`

This PR try to handle such cases