### PR TITLE
fix(telemetry): set redis backend metadata

### DIFF
--- a/lib/nebulex/adapters/redis.ex
+++ b/lib/nebulex/adapters/redis.ex
@@ -528,6 +528,9 @@ defmodule Nebulex.Adapters.Redis do
     # Adapter mode
     mode = Keyword.fetch!(opts, :mode)
 
+    # Adapter backend identifier
+    backend = Keyword.fetch!(opts, :backend)
+
     # Local registry
     registry = camelize_and_concat([name, Registry])
 
@@ -544,6 +547,7 @@ defmodule Nebulex.Adapters.Redis do
         telemetry: telemetry,
         cache_pid: self(),
         name: opts[:name] || cache,
+        backend: backend,
         mode: mode,
         pool_size: pool_size,
         registry: registry,

--- a/lib/nebulex/adapters/redis/options.ex
+++ b/lib/nebulex/adapters/redis/options.ex
@@ -36,6 +36,14 @@ defmodule Nebulex.Adapters.Redis.Options do
 
       """
     ],
+    backend: [
+      type: :atom,
+      required: false,
+      default: :redis,
+      doc: """
+      Backend identifier used in telemetry metadata.
+      """
+    ],
     pool_size: [
       type: :pos_integer,
       required: false,

--- a/test/nebulex/adapters/redis/standalone_test.exs
+++ b/test/nebulex/adapters/redis/standalone_test.exs
@@ -8,6 +8,7 @@ defmodule Nebulex.Adapters.Redis.StandaloneTest do
 
   import Nebulex.CacheCase, only: [safe_stop: 1, t_sleep: 1]
 
+  alias Nebulex.Adapter
   alias Nebulex.Adapters.Redis.TestCache.Standalone, as: Cache
 
   setup do
@@ -102,6 +103,12 @@ defmodule Nebulex.Adapters.Redis.StandaloneTest do
 
       assert cache.get_or_store!("ttl", fn -> "new value" end) == "new value"
       assert cache.get!("ttl") == "new value"
+    end
+  end
+
+  describe "adapter metadata" do
+    test "defaults backend to :redis", %{cache: cache} do
+      assert Adapter.lookup_meta(cache).backend == :redis
     end
   end
 end


### PR DESCRIPTION
## Summary
- add a `:backend` start option defaulting to `:redis` for the Redis adapter
- set `adapter_meta.backend` so telemetry consumers can read a non-nil backend
- add a standalone test to lock in the default

## Motivation
`opentelemetry_nebulex` reads `metadata.adapter_meta[:backend]` to populate DB system attributes. For the Redis adapter this was always `nil`, so spans missed the backend identifier. Defaulting to `:redis` aligns with other adapters and keeps telemetry metadata consistent.

## Test plan
- NEBULEX_PATH=nebulex mix test test/nebulex/adapters/redis/standalone_test.exs